### PR TITLE
remove word `below` on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
             <aside>
                 <h3>1. Install Scriptable</h3>
                 <p><a href="https://apps.apple.com/app/scriptable/id1405459188" target="_blank"><em>Download Scriptable ↗</em></a></p>
-                <p>If you have not downloaded Scriptable from the AppStore yet, please click on the download button below.</p>
+                <p>If you have not downloaded Scriptable from the AppStore yet, please click on the download button.</p>
             </aside>
             <aside>
                 <h3>2. Copy Installer Script</h3>


### PR DESCRIPTION
the download button is above the text. so removing word below.